### PR TITLE
Added LUKS type to boot partition section

### DIFF
--- a/book/arch/04-prepare-volumes.md
+++ b/book/arch/04-prepare-volumes.md
@@ -37,7 +37,7 @@ Use a strong password which you can remember.
 > Be aware, GRUB boot loader uses US keyboard layout. German users should execute `loadkeys us` before running `cryptsetup` commands.
 
 ```
-cryptsetup luksFormat /dev/[device 3rd partition]
+cryptsetup luksFormat --type luks1 /dev/[device 3rd partition]
 cryptsetup open /dev/[device 3rd partition] cryptboot
 
 ls /dev/mapper


### PR DESCRIPTION
As stated at https://wiki.archlinux.org/index.php/Dm-crypt/Encrypting_an_entire_system#Preparing_the_disk_5 GRUB doesn't support the luks2 format which appears to be the default time at this time, to prevent a non bootable GRUB installation `--type luks1` should be added to the according command.